### PR TITLE
Append to odbc.ini Instead of Replacing it

### DIFF
--- a/install/newfies-dialer-functions.sh
+++ b/install/newfies-dialer-functions.sh
@@ -561,7 +561,7 @@ func_prepare_settings(){
     sed -i "s/5432/$DB_PORT/" $LUA_DIR/libs/settings.lua
 
     #ODBC
-    cp /usr/src/newfies-dialer/install/odbc/odbc.ini /etc/odbc.ini
+    cat /usr/src/newfies-dialer/install/odbc/odbc.ini >> /etc/odbc.ini
     #Setup odbc.ini for POSTGRESQL
     sed -i "s/DATABASENAME/$DATABASENAME/" /etc/odbc.ini
     sed -i "s/DB_USERNAME/$DB_USERNAME/" /etc/odbc.ini


### PR DESCRIPTION
I came across this when I was running this install on a staging box that happens to run other development API services that utilize ODBC. It took us a little bit to track this one down but after we opened up the odbc.ini as a longshot (because nobody would have thought it was changed) and we saw the newfies dialer installation was the culprit. 

This commit will append to odbc.ini instead of completely replacing it. I looked throughout the project and did not see odbc.ini touched elsewhere but if you need me to make changes somewhere else just let me know. I also didn't see any contribution guidelines so if this isn't the branch to merge into just let me know. 